### PR TITLE
Feature audit logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /charts/*
+.vscode

--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ kubectl -n cattle-system create secret generic tls-ca --from-file=cacerts.pem
 
 | Option | Default Value | Description |
 | --- | --- | --- |
+| `auditLog.destination` | "sidecar" | `string` - Stream to sidecar container console or hostPath volume - "sidecar, hostPath" |
+| `auditLog.hostPath` | "/var/log/rancher/audit" | `string` - log file destination on host |
+| `auditLog.maxAge` | 1 | `int` - maximum number of days to retain old audit log files |
+| `auditLog.maxBackups` | 1 | `int` - maximum number of audit log files to retain |
+| `auditLog.maxSize` | 100 | `int` - maximum size in megabytes of the audit log file before it gets rotated |
 | `debug` | false | `bool` - set debug flag on rancher server |
 | `imagePullSecrets` | [] | `list` - list of names of Secret resource containing private registry credentials |
 | `noProxy` | "127.0.0.1,localhost" | `string` - comma separated list of domains/IPs that will not use the proxy |
@@ -156,7 +161,9 @@ Enable Rancher [Audit Logging](https://rancher.com/docs/rancher/v2.x/en/installa
 --set auditLog.level=1
 ```
 
-Enabling Audit Logging will create a sidecar container in the Rancher pod. This container (`rancher-audit-log`) will stream the log to `stdout`.  You can collect this log as you would any container log. Enable the [Logging service under Rancher Tools](https://rancher.com/docs/rancher/v2.x/en/tools/logging/) for the Rancher server cluster or System Project.
+By default enabling Audit Logging will create a sidecar container in the Rancher pod. This container (`rancher-audit-log`) will stream the log to `stdout`.  You can collect this log as you would any container log. Enable the [Logging service under Rancher Tools](https://rancher.com/docs/rancher/v2.x/en/tools/logging/) for the Rancher server cluster or System Project.
+
+Set the `auditLog.destination` to `hostPath` to forward logs to volume shared with the host system instead of streaming to a sidecar container.
 
 ## Private or Air Gap Registry
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ kubectl -n cattle-system create secret generic tls-ca --from-file=cacerts.pem
 
 | Option | Default Value | Description |
 | --- | --- | --- |
+| `auditLog.level` | 0 | `int` - Audit log level - [0-3] |
 | `hostname` | "" | `string` - the Fully Qualified Domain Name for your Rancher Server |
 | `tls` | "ingress" | `string` - Where to terminate ssl/tls - "ingress, external" |
 | `ingress.tls.source` | "rancher" | `string` - Where to get the cert for the ingress. - "rancher, letsEncrypt, secret" |
@@ -146,6 +147,16 @@ kubectl -n cattle-system create secret generic tls-ca --from-file=cacerts.pem
 | `resources` | {} | `map` - rancher pod resource requests & limits |
 | `rancherImage` | "rancher/rancher" | `string` - rancher image source |
 | `rancherImageTag` | same as chart version | `string` - rancher/rancher image tag |
+
+## Audit Logs
+
+Enable Rancher [Audit Logging](https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/).
+
+```shell
+--set auditLog.level=1
+```
+
+Enabling Audit Logging will create a sidecar container in the Rancher pod. This container (`rancher-audit-log`) will stream the log to `stdout`.  You can collect this log as you would any container log. Enable the [Logging service under Rancher Tools](https://rancher.com/docs/rancher/v2.x/en/tools/logging/) for the Rancher server cluster or System Project.
 
 ## Private or Air Gap Registry
 

--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -60,11 +60,11 @@ spec:
         - name: AUDIT_LEVEL
           value: {{ .Values.auditLog.level | quote }}
         - name: AUDIT_LOG_MAXAGE
-          value: "10"
+          value: {{ .Values,auditLog.maxAge | quote }}
         - name: AUDIT_LOG_MAXBACKUP
-          value: "1"
+          value: {{ .Values.auditLog.maxBackup | quote }}
         - name: AUDIT_LOG_MAXSIZE
-          value: "100"
+          value: {{ .Values.auditLog.maxSize | quote }}
 {{- end }}
 {{- if .Values.proxy }}
         - name: HTTP_PROXY
@@ -115,8 +115,15 @@ spec:
 {{- end }}
       volumes:
 {{- if gt .Values.auditLog.level 0.0 }}
+  {{- if eq .Values.auditLog.destination "hostPath" }}
+      - name: audit-log
+        hostPath:
+          path: {{ .Values.auditLog.hostPath }}
+          type: DirectoryOrCreate
+  {{- else }}
       - name: audit-log
         emptyDir: {}
+  {{- end }}
 {{- end }}
 {{- if .Values.privateCA }}
       - name: tls-ca-volume

--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -42,8 +42,18 @@ spec:
 {{- end }}
         - "--http-listen-port=80"
         - "--https-listen-port=443"
-{{- if .Values.proxy }}
         env:
+{{- if gt .Values.auditLog.level 0.0 }}
+        - name: AUDIT_LEVEL
+          value: {{ .Values.auditLog.level | quote }}
+        - name: AUDIT_LOG_MAXAGE
+          value: "10"
+        - name: AUDIT_LOG_MAXBACKUP
+          value: "1"
+        - name: AUDIT_LOG_MAXSIZE
+          value: "100"
+{{- end }}
+{{- if .Values.proxy }}
         - name: HTTP_PROXY
           value: {{ .Values.proxy }}
         - name: HTTPS_PROXY
@@ -69,13 +79,33 @@ spec:
           periodSeconds: 30
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+{{- if gt .Values.auditLog.level 0.0 }}
+        - mountPath: /var/log/auditlog
+          name: audit-log
+{{- end }}
 {{- if .Values.privateCA }}
         # Pass CA cert into rancher for private CA
-        volumeMounts:
         - mountPath: /etc/rancher/ssl
           name: tls-ca-volume
           readOnly: true
+{{- end }}
+{{- if gt .Values.auditLog.level 0.0 }}
+      # Make audit logs avalible for Rancher log collecter tools.
+      - image: busybox
+        name: {{ template "rancher.name" . }}-audit-log
+        command: ["tail"]
+        args: ["-F", "/var/log/auditlog/rancher-api-audit.log"]
+        volumeMounts:
+        - mountPath: /var/log/auditlog
+          name: audit-log
+{{- end }}
       volumes:
+{{- if gt .Values.auditLog.level 0.0 }}
+      - name: audit-log
+        emptyDir: {}
+{{- end }}
+{{- if .Values.privateCA }}
       - name: tls-ca-volume
         secret:
           defaultMode: 420

--- a/rancher/values.yaml
+++ b/rancher/values.yaml
@@ -1,8 +1,15 @@
 # Audit Logs https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/
 # The audit log is piped to the console of the rancher-audit-log container in the rancher pod.
+# https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/
+# destination stream to sidecar container console or hostPath volume
 # level: Verbosity of logs, 0 to 3. 0 is off 3 is a lot.
 auditLog:
+  destination: sidecar
+  hostPath: /var/log/rancher/audit/
   level: 0
+  maxAge: 1
+  maxBackup: 1
+  maxSize: 100
 
 # Add debug flag to Rancher server
 debug: false

--- a/rancher/values.yaml
+++ b/rancher/values.yaml
@@ -1,3 +1,9 @@
+# Audit Logs https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/
+# The audit log is piped to the console of the rancher-audit-log container in the rancher pod.
+# level: Verbosity of logs, 0 to 3. 0 is off 3 is a lot.
+auditLog:
+  level: 0
+
 # Add debug flag to Rancher server
 debug: false
 
@@ -32,7 +38,6 @@ privateCA: false
 
 # comma separated list of domains or ip addresses that will not use the proxy 
 noProxy: localhost,127.0.0.1
-
 
 # Override rancher image location for Air Gap installs
 rancherImage: rancher/rancher


### PR DESCRIPTION
Add audit log.

Enabling audit log creates a sidecar container to tail and display the log to the container out.  From there you can use standard container log collection to push it into a logging system.