### PR TITLE
Fix #18 Include Addtional CA certs, Fix #14 Remove external tls support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /charts/*
+.vscode

--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ helm install rancher-stable/rancher --name rancher --namespace cattle-system \
 --set letsEncrypt.email=me@example.org
 ```
 
-> LetsEncrypt ProTip: The default `production` environment only allows you to register a name 5 times in a week. If you're rebuilding a bunch of times, use `--set letsEncrypt.environment=staging` until you have you're confident your config is right.
-
 #### Ingress Certs from Files (Kubernetes Secret)
 
 Create Kubernetes Secrets from your own cert for Rancher to use.
@@ -88,18 +86,6 @@ helm install rancher-stable/rancher --name rancher --namespace cattle-system \
 ```
 
 Now that Rancher is running, see [Adding TLS Secrets](#Adding-TLS-Secrets) to publish the certificate files so Rancher and the Ingress Controller can use them.
-
-### External SSL Termination
-
-If you're going to handle the SSL termination on a load balancer or proxy before the Ingress, set `tls=external`
-
-> NOTE: If you are using a private CA signed cert, you will need to provide the CA cert to Rancher server. Add `--set privateCA=true` option and see [Private CA Signed - Additional Steps](#Private-CA-Signed---Additional-Steps).
-
-```shell
-helm install rancher-stable/rancher --name rancher --namespace cattle-system \
---set hostname=rancher.my.org \
---set tls=external
-```
 
 ## Adding TLS Secrets
 
@@ -128,7 +114,6 @@ kubectl -n cattle-system create secret generic tls-ca --from-file=cacerts.pem
 | Option | Default Value | Description |
 | --- | --- | --- |
 | `hostname` | "" | `string` - the Fully Qualified Domain Name for your Rancher Server |
-| `tls` | "ingress" | `string` - Where to terminate ssl/tls - "ingress, external" |
 | `ingress.tls.source` | "rancher" | `string` - Where to get the cert for the ingress. - "rancher, letsEncrypt, secret" |
 | `letsEncrypt.email` | "none@example.com" | `string` - Your email address |
 | `letsEncrypt.environment` | "production" | `string` - Valid options: "staging, production" |
@@ -139,9 +124,10 @@ kubectl -n cattle-system create secret generic tls-ca --from-file=cacerts.pem
 
 | Option | Default Value | Description |
 | --- | --- | --- |
+| `additionalTrustedCAs` | false | `bool` - See [Additional Trusted CAs](#additional-trusted-cas) |
 | `debug` | false | `bool` - set debug flag on rancher server |
 | `imagePullSecrets` | [] | `list` - list of names of Secret resource containing private registry credentials |
-| `noProxy` | "127.0.0.1,localhost" | `string` - comma separated list of domains/IPs that will not use the proxy |
+| `noProxy` | "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" | `string` - comma separated list of domains/IPs that will not use the proxy |
 | `proxy` | "" | `string` - HTTP[S] proxy server for Rancher |
 | `resources` | {} | `map` - rancher pod resource requests & limits |
 | `rancherImage` | "rancher/rancher" | `string` - rancher image source |
@@ -170,7 +156,21 @@ Rancher requires internet access for some functionality (helm charts). Set `prox
 
 ```shell
 --set proxy="http://<username>:<password>@<proxy_url>:<proxy_port>/"
---set noProxy="127.0.0.1,localhost,myinternaldomain.example.com"
+--set noProxy="127.0.0.0/8\,10.0.0.0/8\,172.16.0.0/12\,192.168.0.0/16"
+```
+
+## Additional Trusted CAs
+
+If you have private registries, catalogs or a proxy that intercepts certificates, you may need to add additional trusted CAs to Rancher.
+
+```shell
+--set additionalTrustedCAs=true
+```
+
+Once the Rancher deployment is created, copy your CA certs in pem format into a file named `ca-additional.pem` and use `kubectl` to create the `tls-ca-additional` secret in the `cattle-system` namespace.
+
+```shell
+kubectl -n cattle-system create secret generic tls-ca-additional --from-file=ca-additional.pem
 ```
 
 ## Connecting to Rancher

--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -26,8 +26,6 @@ spec:
         ports:
         - containerPort: 80
           protocol: TCP
-        - containerPort: 443
-          protocol: TCP
         args:
 {{- if .Values.debug }}
         - "--debug"
@@ -48,13 +46,7 @@ spec:
           value: {{ .Values.proxy }}
         - name: HTTPS_PROXY
           value: {{ .Values.proxy }}
-        - name: http_proxy
-          value: {{ .Values.proxy }}
-        - name: https_proxy
-          value: {{ .Values.proxy }}
         - name: NO_PROXY
-          value: {{ .Values.noProxy }}
-        - name: no_proxy
           value: {{ .Values.noProxy }}
 {{- end }}
         livenessProbe:
@@ -69,13 +61,27 @@ spec:
           periodSeconds: 30
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+{{- if .Values.additionalTrustedCAs }}
+        - mountPath: /etc/ssl/certs/ca-additional.pem
+          name: tls-ca-additional-volume
+          subPath: ca-additional.pem
+          readOnly: true
+{{- end }}
 {{- if .Values.privateCA }}
         # Pass CA cert into rancher for private CA
-        volumeMounts:
         - mountPath: /etc/rancher/ssl
           name: tls-ca-volume
           readOnly: true
+{{- end }}
       volumes:
+{{- if .Values.additionalTrustedCAs }}
+      - name: tls-ca-additional-volume
+        secret:
+          defaultMode: 420
+          secretName: tls-ca-additional
+{{- end }}
+{{- if .Values.privateCA }}
       - name: tls-ca-volume
         secret:
           defaultMode: 420

--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -78,12 +78,12 @@ spec:
 {{- if .Values.additionalTrustedCAs }}
       - name: tls-ca-additional-volume
         secret:
-          defaultMode: 420
+          defaultMode: 440
           secretName: tls-ca-additional
 {{- end }}
 {{- if .Values.privateCA }}
       - name: tls-ca-volume
         secret:
-          defaultMode: 420
+          defaultMode: 750
           secretName: tls-ca
 {{- end }}

--- a/rancher/templates/ingress.yaml
+++ b/rancher/templates/ingress.yaml
@@ -11,12 +11,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
-{{- if eq .Values.tls "external" }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "false" # turn off ssl redirect for external.
-{{- else }}
-  {{- if ne .Values.ingress.tls.source "secret" }}
+{{- if ne .Values.ingress.tls.source "secret" }}
     certmanager.k8s.io/issuer: {{ template "rancher.fullname" . }}
-  {{- end }}
 {{- end }}
 spec:
   rules:
@@ -26,9 +22,8 @@ spec:
       - backend:
           serviceName: {{ template "rancher.fullname" . }}
           servicePort: 80
-{{- if eq .Values.tls "ingress" }}
   tls:
   - hosts:
     - {{ .Values.hostname }}
     secretName: tls-rancher-ingress
-{{- end }}
+

--- a/rancher/values.yaml
+++ b/rancher/values.yaml
@@ -1,3 +1,8 @@
+# Additional Trusted CAs.
+# Enable this flag and add your CA certs as a secret named tls-ca-additional in the namespace.
+# See README.md for details.
+additionalTrustedCAs: false
+
 # Add debug flag to Rancher server
 debug: false
 
@@ -10,7 +15,7 @@ imagePullSecrets: []
 # - name: secretName
 
 ### ingress ###
-# See tls section for details.
+# Readme for details and instruction on adding tls secrets.
 ingress:
   tls:
     # rancher, letsEncrypt, secrets
@@ -28,11 +33,10 @@ letsEncrypt:
 privateCA: false
 
 # http[s] proxy server passed into rancher server.
-# proxy:
+# proxy: http://<username>@<password>:<url>:<port>
 
 # comma separated list of domains or ip addresses that will not use the proxy 
-noProxy: localhost,127.0.0.1
-
+noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 
 
 # Override rancher image location for Air Gap installs
 rancherImage: rancher/rancher
@@ -45,36 +49,3 @@ replicas: 1
 
 # Set pod resource requests/limits for Rancher.
 resources: {}
-
-### tls ###
-#   Where to offload the TLS/SSL encrytion
-#
-# - ingress (default)
-#   SSL on the ingress.
-#
-#   - (Default) Use Rancher generated "Self-Signed" Certs
-#     Rancher will populate the <namespace>/rancher-tls secrets with the CA key and cert so cert-manager can
-#     issue a cert for you.
-#     tls: ingress
-#     ingress.tls.source: rancher
-#
-#   - Use LetsEncrypt to issue certs
-#     tls: ingress
-#     ingress.tls.source: letsEncrypt
-#     letsEncrypt.email: your.name@example.com
-#     letsEncrypt.environment: prod
-#
-#   - Use certs from secret.
-#     Add the tls.key and tls.crt values to the 'tls-rancher' secret in the 'cattle-system' namespace.
-#     See the README.md for more details.
-#     NOTE: If you are using private CA signed certs see 'privateCA:'
-#     tls: ingress
-#     ingress.tls.source: secret
-#
-# - external
-#   Offload SSL at an external source like an external load balancer.
-#   NOTE: If you are using private CA signed certs see 'privateCA:'
-#
-#   tls: external
-#
-tls: ingress


### PR DESCRIPTION
- fixes #18 Ability to add additional CA certs for things like MITM Proxy.
- fixes #14 Remove TLS offload on external LB support. You can still do L7 and certs on your LB, but the Ingress endpoint will still have a cert.   