### PR TITLE
Fix invalid anti-affinity rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /charts/*
+.vscode

--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -23,13 +23,12 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - {{ template "rancher.fullname" . }}
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ template "rancher.fullname" . }}
             topologyKey: kubernetes.io/hostname
       containers:
       - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}


### PR DESCRIPTION
Mixed up the "required" and "preferred" affinity blocks.  Not sure why this validated and k8s applied it in the first place?!?

Now when you power off a node, the running pod will go into unknown and replacement will be pending waiting for a healthy node. This takes a few min for health checks to resolve and deployment to attempt to reschedule.

Helm launched with replicas=3
```plain
helm install ./ --name rancher --namespace cattle-system --set hostname=jgreat-test-1.rancher.space --set replicas=3 --set rancherImageTag=master
```

One "broken" node
```yaml
kubectl get nodes
NAME             STATUS     ROLES                      AGE       VERSION
18.191.233.31    Ready      controlplane,etcd,worker   26m       v1.11.2
18.223.107.144   NotReady   controlplane,etcd,worker   26m       v1.11.2
18.224.69.249    Ready      controlplane,etcd,worker   26m       v1.11.2
```

Pod in pending
```yaml
kubectl -n cattle-system get pods -o wide                   
NAME                       READY     STATUS    RESTARTS   AGE       IP          NODE             NOMINATED NODE
rancher-79695888d9-8rg5x   1/1       Unknown   1          10m       10.42.0.6   18.223.107.144   <none>
rancher-79695888d9-cf5c2   0/1       Pending   0          3m        <none>      <none>           <none>
rancher-79695888d9-v9ffb   1/1       Running   1          10m       10.42.1.3   18.224.69.249    <none>
rancher-79695888d9-zj8qv   1/1       Running   1          10m       10.42.2.3   18.191.233.31    <none>
```

