### PR TITLE
fix octal permissions

### DIFF
--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -116,13 +116,13 @@ spec:
 {{- if .Values.additionalTrustedCAs }}
       - name: tls-ca-additional-volume
         secret:
-          defaultMode: 0440
+          defaultMode: 0400
           secretName: tls-ca-additional
 {{- end }}
 {{- if .Values.privateCA }}
       - name: tls-ca-volume
         secret:
-          defaultMode: 0750
+          defaultMode: 0400
           secretName: tls-ca
 {{- end }}
 {{- if gt .Values.auditLog.level 0.0 }}

--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -116,13 +116,13 @@ spec:
 {{- if .Values.additionalTrustedCAs }}
       - name: tls-ca-additional-volume
         secret:
-          defaultMode: 440
+          defaultMode: 0440
           secretName: tls-ca-additional
 {{- end }}
 {{- if .Values.privateCA }}
       - name: tls-ca-volume
         secret:
-          defaultMode: 750
+          defaultMode: 0750
           secretName: tls-ca
 {{- end }}
 {{- if gt .Values.auditLog.level 0.0 }}


### PR DESCRIPTION
Kubernetes charts accepts the common octal format for permission, but reads them as decimal if you don't have the leading 0.
