### PR TITLE
Switch to soft anit-affinity

### DIFF
--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -22,6 +22,16 @@ spec:
 {{- end }}
       affinity:
         podAntiAffinity:
+{{- if eq .Values.anitAffinity "required" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ template "rancher.fullname" . }}
+            topologyKey: kubernetes.io/hostname
+{{- else }}
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
@@ -32,6 +42,7 @@ spec:
                   values:
                   - {{ template "rancher.fullname" . }}
               topologyKey: kubernetes.io/hostname
+{{- end }}
       containers:
       - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
         name: {{ template "rancher.name" . }}

--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
 {{- end }}
       affinity:
         podAntiAffinity:
-{{- if eq .Values.anitAffinity "required" }}
+{{- if eq .Values.antiAffinity "required" }}
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:

--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "rancher.fullname" . }}
   labels:
@@ -22,14 +22,16 @@ spec:
 {{- end }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - {{ template "rancher.fullname" . }}
-            topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "rancher.fullname" . }}
+              topologyKey: kubernetes.io/hostname
       containers:
       - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
         name: {{ template "rancher.name" . }}

--- a/rancher/values.yaml
+++ b/rancher/values.yaml
@@ -2,6 +2,9 @@
 # Enable this flag and add your CA certs as a secret named tls-ca-additional in the namespace.
 # See README.md for details.
 additionalTrustedCAs: false
+
+antiAffinity: preferred
+
 # Audit Logs https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/
 # The audit log is piped to the console of the rancher-audit-log container in the rancher pod.
 # https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/


### PR DESCRIPTION
- change `apiVersion`.  `extensions/v1beta1` was deprecated back in k8s 1.8.
- change to soft anti-afinity rules so single node installs upgrade. rancher/rancher#16068

The change to soft anti-affinity rules comes with some compromises.  

- `rancher` pods will prefer to be on a node without other `rancher` pods, but may end up being scheduled on the same node as another `rancher` pod.
- If installed with the default replica value on a single node cluster you will have 3 rancher pods running on that single node.

Tested upgrade paths for single node. 
Note: while at chart versions 2.1.0 and 2018.10.1 the old 2.0.8 pods were stuck running rancher/rancher#16068

- 2.0.8 -> 2.1.0 -> 2018.10.1 -> ./rancher
- 2.0.8 -> 2.1.0 -> ./rancher
- 2.0.8 -> 2018.10.1 -> ./rancher
- 2.0.8 -> ./rancher

Tested upgrade path for 3 nodes.
Note: there was no issue upgrading with 3 nodes.

- 2.0.8 -> 2.1.0 -> 2018.10.1 -> ./rancher
- 2.0.8 -> 2.1.0 -> ./rancher
- 2.0.8 -> ./rancher


