### PR TITLE
Make certmanager Issuer name configurable

### DIFF
--- a/rancher/templates/ingress.yaml
+++ b/rancher/templates/ingress.yaml
@@ -14,7 +14,9 @@ metadata:
 {{- if eq .Values.tls "external" }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false" # turn off ssl redirect for external.
 {{- else }}
-  {{- if ne .Values.ingress.tls.source "secret" }}
+  {{- if .Values.ingress.tls.issuerName }}
+    certmanager.k8s.io/issuer: {{ .Values.ingress.tls.issuerName }}
+  {{- else if ne .Values.ingress.tls.source "secret" }}
     certmanager.k8s.io/issuer: {{ template "rancher.fullname" . }}
   {{- end }}
 {{- end }}

--- a/rancher/templates/ingress.yaml
+++ b/rancher/templates/ingress.yaml
@@ -14,7 +14,9 @@ metadata:
 {{- if eq .Values.tls "external" }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false" # turn off ssl redirect for external.
 {{- else }}
-  {{- if .Values.ingress.tls.issuerName }}
+  {{- if eq .Values.ingress.tls.source "clusterIssuer" }}
+    certmanager.k8s.io/cluster-issuer: {{ .Values.ingress.tls.issuerName }}
+  {{- else if eq .Values.ingress.tls.source "issuer" }}
     certmanager.k8s.io/issuer: {{ .Values.ingress.tls.issuerName }}
   {{- else if ne .Values.ingress.tls.source "secret" }}
     certmanager.k8s.io/issuer: {{ template "rancher.fullname" . }}

--- a/rancher/values.yaml
+++ b/rancher/values.yaml
@@ -35,6 +35,8 @@ ingress:
   tls:
     # rancher, letsEncrypt, secrets
     source: rancher
+    # Set the issuerName of the ClusterIssuer or Issuer resource in the rancher namespace (CertManager)
+    # issuerName:
 
 ### LetsEncrypt config ###
 # ProTip: The production environment only allows you to register a name 5 times a week.

--- a/rancher/values.yaml
+++ b/rancher/values.yaml
@@ -33,9 +33,10 @@ imagePullSecrets: []
 # Readme for details and instruction on adding tls secrets.
 ingress:
   tls:
-    # rancher, letsEncrypt, secrets
+    # rancher, letsEncrypt, secret, issuer, clusterIssuer
     source: rancher
-    # Set the issuerName of the ClusterIssuer or Issuer resource in the rancher namespace (CertManager)
+    # Set the issuerName of the ClusterIssuer or Issuer resource (CertManager). 
+    #   Source must be ingress.tls.source must be issuer or clusterIssuer
     # issuerName:
 
 ### LetsEncrypt config ###


### PR DESCRIPTION
Possible solution for https://github.com/rancher/rancher/issues/16178 .

If `ingress.tls.issuerName` is configured the name will be used for `certmanager.k8s.io/issuer` otherwise the behaviour will remain the same was before.

If this is used the `ingress.tls.source` property should be something other than `rancher`, `letsEncrypt` or  secret`.

