### PR TITLE
add spec.selector fields

### DIFF
--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "rancher.fullname" . }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Fixes regression for new installs.  It seems this field is not automatically set by the apps/v1 API.