### PR TITLE
Convert to dapper

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,6 +4,8 @@ pipeline:
     image: rancher/dapper:1.11.2
     commands:
       - dapper ci
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     when:
       ref:
         exclude: [ regs/tags/*stable* ]
@@ -12,6 +14,8 @@ pipeline:
     image: rancher/dapper:1.11.2
     commands:
       - dapper promote
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     when:
       branch: master
       event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,22 +1,24 @@
 ---
 pipeline:
   build:
-    image: debian
+    image: rancher/dapper:1.11.2
     commands:
-      - apt-get update
-      - apt-get install -y curl ca-certificates git
-      # Install latest helm and unittest plugin
-      - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
-      - helm init -c
-      - helm plugin install https://github.com/lrills/helm-unittest
-      # Helm - lint, test and package
-      - ./scripts/test
-      - helm package -d ./charts/latest ./rancher
-      # Pull and update Index 
-      - curl -o /tmp/index.yaml https://releases.rancher.com/server-charts/latest/index.yaml
-      - helm repo index --merge /tmp/index.yaml ./charts/latest
+      - dapper ci
+    when:
+      ref:
+        exclude: [ regs/tags/*stable* ]
 
-  publish:
+  promote_stable:
+    image: rancher/dapper:1.11.2
+    commands:
+      - dapper promote
+    when:
+      branch: master
+      event: tag
+      ref:
+        include: [ regs/tags/*stable* ]
+
+  publish-latest:
     image: plugins/gcs
     source: charts/latest
     target: releases.rancher.com/server-charts/latest
@@ -29,3 +31,21 @@ pipeline:
     when:
       branch: master
       event: tag
+      ref:
+        exclude: [ regs/tags/*stable* ]
+
+  publish-stable:
+    image: plugins/gcs
+    source: charts/stable
+    target: releases.rancher.com/server-charts/stable
+    acl:
+      - allUsers:READER
+    cache_control: public,max-age=3600
+    secrets:
+      - source: google_auth_key
+        target: GOOGLE_CREDENTIALS
+    when:
+      branch: master
+      event: tag
+      ref:
+        include: [ regs/tags/*stable* ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /charts/*
 .vscode
+.dapper
+*/*.swp

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,0 +1,22 @@
+FROM debian
+
+ARG DAPPER_HOST_ARCH
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+ENV CATTLE_HELM_VERSION v2.10.0-rancher4
+
+RUN apt-get update && \
+    apt-get install -y git curl ca-certificates && \
+    rm -f /bin/sh && ln -s /bin/bash /bin/sh
+
+RUN curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash 
+
+ENV DAPPER_ENV REPO TAG DRONE_TAG
+ENV DAPPER_SOURCE /src/
+ENV DAPPER_OUTPUT ./charts
+ENV DAPPER_DOCKER_SOCKET true
+ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
+ENV HOME ${DAPPER_SOURCE}
+WORKDIR ${DAPPER_SOURCE}
+
+ENTRYPOINT ["./scripts/entry"]
+CMD ["ci"]

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,14 +2,16 @@ FROM debian
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
-ENV CATTLE_HELM_VERSION v2.10.0-rancher4
 
 RUN apt-get update && \
     apt-get install -y git curl ca-certificates && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
-RUN curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash 
+RUN curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash && \
+    helm init -c && \
+    helm plugin install https://github.com/lrills/helm-unittest
 
+ENV HELM_HOME /root/.helm
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /src/
 ENV DAPPER_OUTPUT ./charts

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+TARGETS := $(shell ls scripts)
+
+.dapper:
+	@echo Downloading dapper
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
+	@@chmod +x .dapper.tmp
+	@./.dapper.tmp -v
+	@mv .dapper.tmp .dapper
+
+$(TARGETS): .dapper
+	./.dapper $@
+
+trash: .dapper
+	./.dapper -m bind trash
+
+trash-keep: .dapper
+	./.dapper -m bind trash -k
+
+deps: trash
+
+.DEFAULT_GOAL := ci
+
+.PHONY: $(TARGETS)

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+./validate
+./build
+./test
+./package

--- a/scripts/entry
+++ b/scripts/entry
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+mkdir -p bin dist
+if [ -e ./scripts/$1 ]; then
+    ./scripts/"$@"
+else
+    exec "$@"
+fi
+
+chown -R $DAPPER_UID:$DAPPER_GID .

--- a/scripts/get_and_merge_index
+++ b/scripts/get_and_merge_index
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+repo_index=${1}
+
+curl -sf -o /tmp/index.yaml https://releases.rancher.com/server-charts/${repo_index}/index.yaml
+helm repo index --merge /tmp/index.yaml ./charts/${repo_index}

--- a/scripts/package
+++ b/scripts/package
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+. ./version
+
+cd $(dirname $0)/..
+
+helm package -d ./charts/${CHART_REPO} ./rancher
+
+echo "updating index ... "
+./scripts/get_and_merge_index ${CHART_REPO}

--- a/scripts/promote
+++ b/scripts/promote
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+. ./scripts/version
+cd $(dirname $0)/..
+
+if [ "${CHART_REPO}" = "latest" ]; then
+    echo "error: can not promote from 'latest' to 'latest'"
+    exit 1
+fi
+
+curl -sf -o charts/${CHART_REPO}/rancher-${CHART_VERSION}.tgz https://releases.rancher.com/server-charts/latest/rancher-${CHART_VERSION}.tgz
+
+./scripts/get_and_merge_index ${CHART_REPO}

--- a/scripts/test
+++ b/scripts/test
@@ -2,6 +2,10 @@
 
 set -e
 
+cd $(dirname $0)/..
+
+helm init -c
+helm plugin install https://github.com/lrills/helm-unittest
 
 # Check for helm
 hash helm >/dev/null 2>&1
@@ -18,5 +22,4 @@ if [[ $? > 0 ]]; then
     exit 1
 fi
 
-helm lint ./rancher
 helm unittest ./rancher

--- a/scripts/test
+++ b/scripts/test
@@ -4,9 +4,6 @@ set -e
 
 cd $(dirname $0)/..
 
-helm init -c
-helm plugin install https://github.com/lrills/helm-unittest
-
 # Check for helm
 hash helm >/dev/null 2>&1
 if [[ $? > 0 ]]; then

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd $(dirname $0)/..
+
+# Check for helm
+hash helm >/dev/null 2>&1
+if [[ $? > 0 ]]; then
+    echo "helm not found. Helm is required to run tests."
+    exit 1
+fi
+
+helm lint ./rancher

--- a/scripts/version
+++ b/scripts/version
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    DIRTY="-dirty"
+fi
+
+COMMIT=$(git rev-parse --short HEAD)
+GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
+
+if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
+    VERSION=$GIT_TAG
+else
+    VERSION="${COMMIT}${DIRTY}"
+fi
+
+CHART_VERSION=$(echo ${VERSION}|sed 's/\(^[A-Za-z0-9].*\)-.*/\1/')
+CHART_REPO=$(echo ${VERSION}|sed 's/^[0-9A-Za-z].*-\([a-z0-9A-Z].*\)/\1/')
+
+## Everything goes to latest..
+if [[ "${CHART_REPO}" == "dirty" || "${CHART_REPO}" == "${CHART_VERSION}" ]]; then
+    CHART_REPO=latest
+fi
+
+if [ -z "$ARCH" ]; then
+    ARCH=amd64
+fi


### PR DESCRIPTION
This converts the build/test/etc.. to Dapper and the Rancher `./scripts` directory format.

We will not build on tags with stable, but all other situations should build.
promote will only run on stable, but if we add more channels it is easy to adapt.

Should only upload promoted