### PR TITLE
Remove erroring out when checks on errors exists

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 cd $(dirname $0)/..
 
 # Check for helm

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 cd $(dirname $0)/..
 
 # Check for helm


### PR DESCRIPTION
Error codes are checked in the script but script fails because of error before error condition can be checked