### PR TITLE
adding convenience method for setting ingress timeouts

### DIFF
--- a/rancher/templates/ingress.yaml
+++ b/rancher/templates/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: {{ .Values.proxyConnectTimeout }}
+    nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.proxyReadTimeout }}
+    nginx.ingress.kubernetes.io/proxy-send-timeout: {{ .Values.proxySendTimeout }}
 {{- if eq .Values.tls "external" }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false" # turn off ssl redirect for external.
 {{- else }}

--- a/rancher/values.yaml
+++ b/rancher/values.yaml
@@ -55,8 +55,14 @@ privateCA: false
 # http[s] proxy server passed into rancher server.
 # proxy: http://<username>@<password>:<url>:<port>
 
-# comma separated list of domains or ip addresses that will not use the proxy 
-noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 
+# comma separated list of domains or ip addresses that will not use the proxy
+noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+
+# Values in seconds for configuring the nginx ingress
+# Useful for more aggressively marking nodes dead on bare metal installs
+proxyConnectTimeout: 30
+proxyReadTimeout: 1800
+proxySendTimeout: 1800
 
 # Override rancher image location for Air Gap installs
 rancherImage: rancher/rancher
@@ -70,7 +76,7 @@ replicas: 3
 # Set pod resource requests/limits for Rancher.
 resources: {}
 
-# 
+#
 # tls
 #   Where to offload the TLS/SSL encryption
 # - ingress (default)


### PR DESCRIPTION
**Problem:**

When deploying to bare metal, it seems like it's possible to generate 500s and other weirdness from the UI when a node is dead. This is because the timeout seems way too long. As this applies to a very specific case when I am using the nginx ingress for the rancher UI, I would like to move these values out to something easily set using the `--set` notation in the helm chart.