### PR TITLE
Allow for node port routing

### DIFF
--- a/rancher/templates/service.yaml
+++ b/rancher/templates/service.yaml
@@ -15,3 +15,26 @@ spec:
     name: http
   selector:
     app: {{ template "rancher.fullname" . }}
+
+{{- if .Values.nodeport }}
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "rancher.fullname" . }}-nodport
+  labels:
+    app: {{ template "rancher.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  type: NodePort
+  ports:
+  - port: 443
+    nodePort: {{ .Values.nodeport }}
+    protocol: TCP
+    name: https
+  selector:
+    app: {{ template "rancher.fullname" . }}
+{{- end }}

--- a/rancher/values.yaml
+++ b/rancher/values.yaml
@@ -76,3 +76,5 @@ resources: {}
 # - ingress (default)
 # - external
 tls: ingress
+
+# nodeport: 30001


### PR DESCRIPTION
## What
We use rancher for deploying our nginx ingress controller and we use the nginx ingress controller for routing traffic to rancher. If the nginx ingress controller fails or breaks we loose the ability to use rancher to resolve the nginx issue.

What we want is the ability to reach rancher from a nodeport via our AWS load balancer.