### PR TITLE
Added option ports and annotations for deployment and service

### DIFF
--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -50,8 +50,7 @@ spec:
       - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}
         name: {{ template "rancher.name" . }}
         ports:
-        - containerPort: 80
-          protocol: TCP
+{{ toYaml .Values.deployment.ports | indent 8 -}}
         args:
 {{- if .Values.debug }}
         - "--debug"

--- a/rancher/templates/service.yaml
+++ b/rancher/templates/service.yaml
@@ -7,11 +7,13 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
+  type: {{ default "ClusterIP" .Values.service.type }}
   ports:
-  - port: 80
-    targetPort: 80
-    protocol: TCP
-    name: http
+{{ toYaml .Values.service.ports | indent 4 }}
   selector:
     app: {{ template "rancher.fullname" . }}

--- a/rancher/values.yaml
+++ b/rancher/values.yaml
@@ -33,6 +33,22 @@ debug: false
 imagePullSecrets: []
 # - name: secretName
 
+### service ###
+deployment:
+  ports:
+  - containerPort: 80
+    protocol: TCP
+
+### service ###
+service:
+  annotations: {}
+  # NodePort, LoadBalancer or ClusterIP
+  #type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 80
+    name: http
+
 ### ingress ###
 # Readme for details and instruction on adding tls secrets.
 ingress:


### PR DESCRIPTION
In order to get the chart working on Azure (AKS) extra annotations and changing the service port numbers were required.
I've added the options to the chart which makes it possible to add service specific annotations and specify the deployment and service port(s)