### PR TITLE
Move ingress timeout annotations to values.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 .dapper
 */*.swp
+kube_config_cluster.yml

--- a/rancher/templates/ingress.yaml
+++ b/rancher/templates/ingress.yaml
@@ -8,9 +8,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
 {{- if eq .Values.tls "external" }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false" # turn off ssl redirect for external.
 {{- else }}

--- a/rancher/tests/ingress_test.yaml
+++ b/rancher/tests/ingress_test.yaml
@@ -1,0 +1,49 @@
+suite: Test Ingress
+templates:
+- ingress.yaml
+tests:
+- it: should set external options
+  set:
+    tls: external
+  asserts:
+  - equal:
+      path: metadata.annotations.nginx\.ingress\.kubernetes\.io/ssl-redirect
+      value: "false"
+  - isNull:
+      path: metadata.annotations.certmanager\.k8s\.io/issuer
+  - isNull:
+      path: spec.tls
+- it: should set default annotations
+  asserts:
+  - equal:
+      path: metadata.annotations
+      value:
+        certmanager.k8s.io/issuer: RELEASE-NAME-rancher
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
+- it: should over write proxy-connect-timeout
+  set: 
+    ingress.extraAnnotations:
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
+  asserts:
+  - equal:
+      path: metadata.annotations
+      value:
+        certmanager.k8s.io/issuer: RELEASE-NAME-rancher
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: "15"
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
+- it: should set source secret
+  set:
+    hostname: test
+    ingress.tls.source: secret
+  asserts:
+  - isNull: 
+      path: certmanager\.k8s\.io/issuer
+  - contains:
+      path: spec.tls
+      content:
+        hosts:
+        - test
+        secretName: tls-rancher-ingress

--- a/rancher/values.yaml
+++ b/rancher/values.yaml
@@ -36,7 +36,10 @@ imagePullSecrets: []
 ### ingress ###
 # Readme for details and instruction on adding tls secrets.
 ingress:
-  extraAnnotations: {}
+  extraAnnotations:
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
   tls:
     # rancher, letsEncrypt, secrets
     source: rancher


### PR DESCRIPTION
Moved ingress default annotations to `ingress.extraAnnotations` so ingress timeout values can be customized. 

Added tests for ingress.yaml