### PR TITLE
Update deployment.yaml to use HTTP liveness and rediness probes

### DIFF
--- a/rancher/templates/deployment.yaml
+++ b/rancher/templates/deployment.yaml
@@ -91,12 +91,14 @@ spec:
           value: {{ .Values.noProxy }}
 {{- end }}
         livenessProbe:
-          tcpSocket:
+          httpGet:
+            path: /healthz
             port: 80
           initialDelaySeconds: 60
           periodSeconds: 30
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /healthz
             port: 80
           initialDelaySeconds: 5
           periodSeconds: 30


### PR DESCRIPTION
This both makes the probes more robust and means that cloud providers that take their ingress loadbalancer health checks from the probe configs (Like GKE) will work correctly out the box.