### PR TITLE
V2.1 cache control

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,6 @@ pipeline:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     when:
-      branch: release/*
       event: tag
       ref:
         include: [ refs/tags/*stable* ]
@@ -28,12 +27,11 @@ pipeline:
     target: releases.rancher.com/server-charts/alpha
     acl:
       - allUsers:READER
-    cache_control: public,max-age=3600
+    cache_control: public,no-cache,proxy-revalidate
     secrets:
       - source: google_auth_key
         target: GOOGLE_CREDENTIALS
     when:
-      branch: [master, release/*]
       event: tag
       ref:
         include: [ refs/tags/*alpha* ]
@@ -44,12 +42,11 @@ pipeline:
     target: releases.rancher.com/server-charts/latest
     acl:
       - allUsers:READER
-    cache_control: public,max-age=3600
+    cache_control: public,no-cache,proxy-revalidate
     secrets:
       - source: google_auth_key
         target: GOOGLE_CREDENTIALS
     when:
-      branch: release/*
       event: tag
       ref:
         exclude: [ refs/tags/*stable*, refs/tags/*alpha* ]
@@ -60,12 +57,11 @@ pipeline:
     target: releases.rancher.com/server-charts/stable
     acl:
       - allUsers:READER
-    cache_control: public,max-age=3600
+    cache_control: public,no-cache,proxy-revalidate
     secrets:
       - source: google_auth_key
         target: GOOGLE_CREDENTIALS
     when:
-      branch: release/*
       event: tag
       ref:
         include: [ refs/tags/*stable* ]

--- a/scripts/get_and_merge_index
+++ b/scripts/get_and_merge_index
@@ -2,5 +2,6 @@
 
 repo_index=${1}
 
-curl -sf -H 'Cache-Control: no-cache' -o /tmp/index.yaml https://releases.rancher.com/server-charts/${repo_index}/index.yaml
+curl -f -H 'Cache-Control: max-age=0,no-cache' -H 'Host: releases.rancher.com' "https://c.storage.googleapis.com/server-charts/${repo_index}/index.yaml?$(date +%s%N)" -o /tmp/index.yaml
+
 helm repo index --merge /tmp/index.yaml ./charts/${repo_index}

--- a/scripts/promote
+++ b/scripts/promote
@@ -10,6 +10,6 @@ if [ "${CHART_REPO}" = "latest" ]; then
     exit 1
 fi
 
-curl -sf -o charts/${CHART_REPO}/rancher-${CHART_VERSION}.tgz https://releases.rancher.com/server-charts/latest/rancher-${CHART_VERSION}.tgz
+curl -f -H 'Cache-Control: max-age=0,no-cache' -H 'Host: releases.rancher.com' "https://c.storage.googleapis.com/server-charts/latest/rancher-${CHART_VERSION}.tgz?$(date +%s%N)" -o ./charts/stable/rancher-${CHART_VERSION}.tgz
 
 ./scripts/get_and_merge_index ${CHART_REPO}


### PR DESCRIPTION
Update urls and cache control headers. 

Remove drone branch filters for tags.  If tagged commit is not current head, drone doesn't populate the branch as we expected. 