### PR TITLE
Add service type support.

### DIFF
--- a/rancher/templates/service.yaml
+++ b/rancher/templates/service.yaml
@@ -13,5 +13,9 @@ spec:
     targetPort: 80
     protocol: TCP
     name: http
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http))) }}
+    nodePort: {{ .Values.service.nodePorts.http }}
+    {{- end }}
   selector:
     app: {{ template "rancher.fullname" . }}
+  type: "{{ .Values.service.type }}"

--- a/rancher/values.yaml
+++ b/rancher/values.yaml
@@ -79,3 +79,20 @@ resources: {}
 # - ingress (default)
 # - external
 tls: ingress
+
+#
+# service.type
+#   Kubernetes ServiceTypes allow you to specify what kind of service you want. The default is ClusterIP
+# - ClusterIp
+# - LoadBalancer (cloud provider)
+# - NodePort
+service:
+  type: ClusterIp
+
+  # type: NodePort
+  # nodePorts:
+  #   http: 30080
+  #   https: 30443
+  nodePorts:
+    http: ""
+    https: ""


### PR DESCRIPTION
Add service type support. ClusterIP (default), LoadBalancer (cloud provider support) and NodePort